### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "segment-proxy",
+  "install": "go mod download && go build ./...",
+  "terminals": [
+    {
+      "name": "proxy",
+      "command": "go run main.go -port 8080 -debug",
+      "description": "Segment reverse proxy on port 8080 with debug access logging enabled."
+    }
+  ],
+  "ports": [
+    {
+      "name": "proxy",
+      "port": 8080
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for `segment-proxy` so the repository is usable out of the box in Cursor Cloud Agents.

`segment-proxy` is a small Go reverse proxy that forwards requests to the Segment CDN (`cdn.segment.com`) and Tracking API (`api.segment.io`) and short-circuits bot/crawler traffic.

## What's included

`.cursor/environment.json`:
- Uses Cursor's default base image (already ships Go 1.22.2 — no custom Dockerfile needed).
- `install`: `go mod download && go build ./...` — idempotent dependency refresh + compile.
- `terminals`: runs the proxy via `go run main.go -port 8080 -debug` so its access logs stay visible.
- `ports`: exposes `8080`.

## Validation

Local VM:
- `go build ./...` succeeds; `go test -v -cover ./...` passes (`TestSegmentReverseProxy`, 36.2% coverage).
- Install command verified idempotent (run twice).
- End-to-end proxy exercised against real Segment endpoints:
  - CDN routes (`/v1/projects/...`, `/analytics.js/...`) reach `cdn.segment.com` (Segment's own `Cannot GET - Invalid path or write key provided.` body returned).
  - Tracking route (`/v1/pixel/...`) reaches `api.segment.io`.
  - Bot User-Agent (`googlebot`) requests are filtered: empty `200`, logged as `Ignored request`.

Prebuilt environment build:
- Triggered a draft build from a READY snapshot + the install command → `SUCCEEDED` (install exit code 0).
- Booted a fresh Cloud Agent from that exact build and re-ran the full flow: Go 1.22.2, install + tests pass, and all four proxy routes behave identically (CDN 404, Tracking 400, bot filtered 200).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-149487a5-f596-4fc8-9474-9a7000838172?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-149487a5-f596-4fc8-9474-9a7000838172&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

