### PR TITLE
Fix 502s on Segment GOAWAY: buffer bodies and set Request.GetBody

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,21 +79,40 @@ var bots []string= []string{ "kive-bot-tester",
 	"Prerender"}
 
 
+// maxBufferedBody caps how much of a request body is held in memory for replay.
+// Segment's largest documented payload is a 500 KB batch, so anything past this
+// is not tracking traffic and must not be allowed to exhaust the instance.
+const maxBufferedBody = 1 << 20
+
+// bodyReadCloser pairs a wrapped reader with the original body's Closer.
+type bodyReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
 // bufferRequestBody reads the request body into memory and sets Request.GetBody
 // so the HTTP/2 transport can transparently replay the request. Without GetBody,
 // a graceful shutdown GOAWAY from the upstream server aborts every in-flight
 // request whose body has already been written, which surfaces to the browser as
-// a 502. Tracking payloads are small, so buffering them is cheap.
+// a 502. The transport only replays requests the upstream never processed;
+// recheck net/http's canRetryError for that guarantee when the Go version in the
+// Dockerfile changes. Bodies past maxBufferedBody keep streaming, and so keep the
+// old GOAWAY behavior, rather than being held in memory.
 func bufferRequestBody(req *http.Request) {
 	if req.Body == nil || req.GetBody != nil {
 		return
 	}
-	body, err := ioutil.ReadAll(req.Body)
-	req.Body.Close()
+	body, err := ioutil.ReadAll(io.LimitReader(req.Body, maxBufferedBody+1))
 	if err != nil {
-		log.Printf("failed to buffer request body for replay: %v", err)
+		// Leave the body untouched so the transport surfaces the read failure
+		// and ReverseProxy logs it once, rather than forwarding a short payload.
 		return
 	}
+	if int64(len(body)) > maxBufferedBody {
+		req.Body = bodyReadCloser{io.MultiReader(bytes.NewReader(body), req.Body), req.Body}
+		return
+	}
+	req.Body.Close()
 	req.Body = ioutil.NopCloser(bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
 	req.GetBody = func() (io.ReadCloser, error) {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -76,12 +79,35 @@ var bots []string= []string{ "kive-bot-tester",
 	"Prerender"}
 
 
+// bufferRequestBody reads the request body into memory and sets Request.GetBody
+// so the HTTP/2 transport can transparently replay the request. Without GetBody,
+// a graceful shutdown GOAWAY from the upstream server aborts every in-flight
+// request whose body has already been written, which surfaces to the browser as
+// a 502. Tracking payloads are small, so buffering them is cheap.
+func bufferRequestBody(req *http.Request) {
+	if req.Body == nil || req.GetBody != nil {
+		return
+	}
+	body, err := ioutil.ReadAll(req.Body)
+	req.Body.Close()
+	if err != nil {
+		log.Printf("failed to buffer request body for replay: %v", err)
+		return
+	}
+	req.Body = ioutil.NopCloser(bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return ioutil.NopCloser(bytes.NewReader(body)), nil
+	}
+}
+
 // NewSegmentReverseProxy is adapted from the httputil.NewSingleHostReverseProxy
 // method, modified to dynamically redirect to different servers (CDN or Tracking API)
 // based on the incoming request, and sets the host of the request to the host of of
 // the destination URL.
 func NewSegmentReverseProxy(cdn *url.URL, trackingAPI *url.URL) http.Handler {
 	director := func(req *http.Request) {
+		bufferRequestBody(req)
 
 		// Figure out which server to redirect to based on the incoming request.
 		var target *url.URL

--- a/main.go
+++ b/main.go
@@ -90,6 +90,24 @@ type bodyReadCloser struct {
 	io.Closer
 }
 
+// streamBody puts back the bytes already read, so the transport sees the same
+// stream, and any same failure, it would have seen without buffering.
+func streamBody(req *http.Request, read []byte) {
+	req.Body = bodyReadCloser{io.MultiReader(bytes.NewReader(read), req.Body), req.Body}
+}
+
+// readBody reads one byte past the cap so the caller can tell a body that just
+// fits from one that is too large. A declared length within the cap is trusted
+// only to size the buffer, which keeps a tracking payload to one allocation.
+func readBody(req *http.Request) ([]byte, error) {
+	if n := req.ContentLength; n > 0 && n <= maxBufferedBody {
+		body := make([]byte, n)
+		read, err := io.ReadFull(req.Body, body)
+		return body[:read], err
+	}
+	return ioutil.ReadAll(io.LimitReader(req.Body, maxBufferedBody+1))
+}
+
 // bufferRequestBody reads the request body into memory and sets Request.GetBody
 // so the HTTP/2 transport can transparently replay the request. Without GetBody,
 // a graceful shutdown GOAWAY from the upstream server aborts every in-flight
@@ -102,14 +120,11 @@ func bufferRequestBody(req *http.Request) {
 	if req.Body == nil || req.GetBody != nil {
 		return
 	}
-	body, err := ioutil.ReadAll(io.LimitReader(req.Body, maxBufferedBody+1))
-	if err != nil {
-		// Leave the body untouched so the transport surfaces the read failure
-		// and ReverseProxy logs it once, rather than forwarding a short payload.
-		return
-	}
-	if int64(len(body)) > maxBufferedBody {
-		req.Body = bodyReadCloser{io.MultiReader(bytes.NewReader(body), req.Body), req.Body}
+	body, err := readBody(req)
+	if err != nil || int64(len(body)) > maxBufferedBody {
+		// The body either cannot be replayed or cannot be read, so hand the
+		// transport the original stream instead.
+		streamBody(req, body)
 		return
 	}
 	req.Body.Close()

--- a/main_test.go
+++ b/main_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -52,6 +54,74 @@ func TestSegmentReverseProxy(t *testing.T) {
 
 		cdn.Close()
 		trackingAPI.Close()
+	}
+}
+
+func TestBufferRequestBody(t *testing.T) {
+	payload := `{"event":"test"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/t", strings.NewReader(payload))
+
+	bufferRequestBody(req)
+
+	if req.GetBody == nil {
+		t.Fatal("expected GetBody to be set so the transport can replay the request")
+	}
+	if req.ContentLength != int64(len(payload)) {
+		t.Errorf("expected ContentLength %v, got %v", len(payload), req.ContentLength)
+	}
+
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != payload {
+		t.Errorf("expected body %q, got %q", payload, string(body))
+	}
+
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := ioutil.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(replayed) != payload {
+		t.Errorf("expected replayed body %q, got %q", payload, string(replayed))
+	}
+}
+
+func TestProxyForwardsPostBody(t *testing.T) {
+	payload := `{"event":"test"}`
+
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("CDN unexpected request: %v\n", r.URL)
+	}))
+	defer cdn.Close()
+
+	trackingAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("Tracking API failed to read body: %v", err)
+			return
+		}
+		if string(body) != payload {
+			t.Errorf("expected forwarded body %q, got %q", payload, string(body))
+		}
+	}))
+	defer trackingAPI.Close()
+
+	proxy := httptest.NewServer(NewSegmentReverseProxy(mustParseUrl(cdn.URL), mustParseUrl(trackingAPI.URL)))
+	defer proxy.Close()
+
+	resp, err := http.Post(proxy.URL+"/v1/t", "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status %v, got %v", http.StatusOK, resp.StatusCode)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -91,6 +95,72 @@ func TestBufferRequestBody(t *testing.T) {
 	}
 }
 
+func TestBufferRequestBodyLeavesLargeBodyStreaming(t *testing.T) {
+	payload := bytes.Repeat([]byte("a"), maxBufferedBody+1024)
+	req := httptest.NewRequest(http.MethodPost, "/v1/t", bytes.NewReader(payload))
+	contentLength := req.ContentLength
+
+	bufferRequestBody(req)
+
+	if req.GetBody != nil {
+		t.Error("expected GetBody to stay nil so an oversized body is not held in memory")
+	}
+	if req.ContentLength != contentLength {
+		t.Errorf("expected ContentLength to stay %v, got %v", contentLength, req.ContentLength)
+	}
+
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(body, payload) {
+		t.Errorf("expected the oversized body to be readable in full: got %v bytes, want %v", len(body), len(payload))
+	}
+}
+
+func TestBufferRequestBodySkipsRequestsItCannotHelp(t *testing.T) {
+	withoutBody := httptest.NewRequest(http.MethodGet, "/v1/projects", nil)
+	withoutBody.Body = nil
+	bufferRequestBody(withoutBody)
+	if withoutBody.GetBody != nil {
+		t.Error("expected GetBody to stay nil for a request without a body")
+	}
+
+	replayable := httptest.NewRequest(http.MethodPost, "/v1/t", strings.NewReader("body"))
+	replayable.GetBody = func() (io.ReadCloser, error) {
+		return ioutil.NopCloser(strings.NewReader("sentinel")), nil
+	}
+	bufferRequestBody(replayable)
+	replay, err := replayable.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := ioutil.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(replayed) != "sentinel" {
+		t.Errorf("expected an existing GetBody to be left alone, got %q", string(replayed))
+	}
+}
+
+// TestDirectorBuffersRequestBody guards the wiring: bufferRequestBody is useless
+// unless the director actually calls it before the transport sends the request.
+func TestDirectorBuffersRequestBody(t *testing.T) {
+	handler := NewSegmentReverseProxy(mustParseUrl("https://cdn.example.com"), mustParseUrl("https://api.example.com"))
+	proxy, ok := handler.(*httputil.ReverseProxy)
+	if !ok {
+		t.Fatalf("expected a *httputil.ReverseProxy, got %T", handler)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/t", strings.NewReader(`{"event":"test"}`))
+	proxy.Director(req)
+
+	if req.GetBody == nil {
+		t.Fatal("director must buffer the body so the transport can replay it after a GOAWAY")
+	}
+}
+
 func TestProxyForwardsPostBody(t *testing.T) {
 	payload := `{"event":"test"}`
 
@@ -99,7 +169,9 @@ func TestProxyForwardsPostBody(t *testing.T) {
 	}))
 	defer cdn.Close()
 
+	var hits int32
 	trackingAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("Tracking API failed to read body: %v", err)
@@ -122,6 +194,48 @@ func TestProxyForwardsPostBody(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status %v, got %v", http.StatusOK, resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("expected the Tracking API to be called once, got %v calls", got)
+	}
+}
+
+// TestProxyForwardsOversizedPostBody makes sure the size cap streams a large body
+// through untouched instead of truncating it at maxBufferedBody.
+func TestProxyForwardsOversizedPostBody(t *testing.T) {
+	payload := bytes.Repeat([]byte("a"), maxBufferedBody+1024)
+
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("CDN unexpected request: %v\n", r.URL)
+	}))
+	defer cdn.Close()
+
+	received := make(chan []byte, 1)
+	trackingAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("Tracking API failed to read body: %v", err)
+		}
+		received <- body
+	}))
+	defer trackingAPI.Close()
+
+	proxy := httptest.NewServer(NewSegmentReverseProxy(mustParseUrl(cdn.URL), mustParseUrl(trackingAPI.URL)))
+	defer proxy.Close()
+
+	resp, err := http.Post(proxy.URL+"/v1/t", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status %v, got %v", http.StatusOK, resp.StatusCode)
+	}
+
+	body := <-received
+	if !bytes.Equal(body, payload) {
+		t.Errorf("expected the Tracking API to receive all %v bytes, got %v", len(payload), len(body))
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type SegmentServer int
@@ -95,26 +97,79 @@ func TestBufferRequestBody(t *testing.T) {
 	}
 }
 
-func TestBufferRequestBodyLeavesLargeBodyStreaming(t *testing.T) {
-	payload := bytes.Repeat([]byte("a"), maxBufferedBody+1024)
-	req := httptest.NewRequest(http.MethodPost, "/v1/t", bytes.NewReader(payload))
-	contentLength := req.ContentLength
+// TestBufferRequestBodyCapBoundary pins the edge of the size cap: a body that
+// exactly fits is buffered, one byte more is left streaming, and neither is
+// truncated on the way through.
+func TestBufferRequestBodyCapBoundary(t *testing.T) {
+	cases := []struct {
+		size     int
+		buffered bool
+	}{
+		{maxBufferedBody - 1, true},
+		{maxBufferedBody, true},
+		{maxBufferedBody + 1, false},
+	}
+	for _, c := range cases {
+		payload := bytes.Repeat([]byte("a"), c.size)
+		req := httptest.NewRequest(http.MethodPost, "/v1/t", bytes.NewReader(payload))
+
+		bufferRequestBody(req)
+
+		if buffered := req.GetBody != nil; buffered != c.buffered {
+			t.Errorf("size %v: expected buffered=%v, got %v", c.size, c.buffered, buffered)
+		}
+		if req.ContentLength != int64(c.size) {
+			t.Errorf("size %v: expected ContentLength %v, got %v", c.size, c.size, req.ContentLength)
+		}
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("size %v: %v", c.size, err)
+		}
+		if !bytes.Equal(body, payload) {
+			t.Errorf("size %v: expected the body to stay intact, got %v bytes", c.size, len(body))
+		}
+	}
+}
+
+// failingBody yields a prefix and then fails, standing in for a client that
+// disconnects partway through its upload.
+type failingBody struct {
+	prefix []byte
+	sent   bool
+}
+
+func (b *failingBody) Read(p []byte) (int, error) {
+	if !b.sent {
+		b.sent = true
+		return copy(p, b.prefix), nil
+	}
+	return 0, errBodyRead
+}
+
+func (b *failingBody) Close() error { return nil }
+
+var errBodyRead = errors.New("simulated client disconnect")
+
+func TestBufferRequestBodyKeepsConsumedBytesOnReadError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/t", nil)
+	req.Body = &failingBody{prefix: []byte("hello")}
+	req.ContentLength = 11
 
 	bufferRequestBody(req)
 
 	if req.GetBody != nil {
-		t.Error("expected GetBody to stay nil so an oversized body is not held in memory")
+		t.Error("expected GetBody to stay nil when the body could not be read")
 	}
-	if req.ContentLength != contentLength {
-		t.Errorf("expected ContentLength to stay %v, got %v", contentLength, req.ContentLength)
+	if req.ContentLength != 11 {
+		t.Errorf("expected ContentLength to stay 11, got %v", req.ContentLength)
 	}
 
 	body, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
+	if string(body) != "hello" {
+		t.Errorf("expected the bytes already consumed to be handed back, got %q", string(body))
 	}
-	if !bytes.Equal(body, payload) {
-		t.Errorf("expected the oversized body to be readable in full: got %v bytes, want %v", len(body), len(payload))
+	if err != errBodyRead {
+		t.Errorf("expected the original read error to reach the transport, got %v", err)
 	}
 }
 
@@ -233,9 +288,13 @@ func TestProxyForwardsOversizedPostBody(t *testing.T) {
 		t.Errorf("expected status %v, got %v", http.StatusOK, resp.StatusCode)
 	}
 
-	body := <-received
-	if !bytes.Equal(body, payload) {
-		t.Errorf("expected the Tracking API to receive all %v bytes, got %v", len(payload), len(body))
+	select {
+	case body := <-received:
+		if !bytes.Equal(body, payload) {
+			t.Errorf("expected the Tracking API to receive all %v bytes, got %v", len(payload), len(body))
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("the Tracking API never received the request")
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

The Cloud Run service `segment-proxy-5b22cbf` (project `airpict`, image `gcr.io/airpict/segment-proxy`) intermittently returns 502s to browsers, tripping the "PROD-segment-proxy: Logs With Severity ERROR above threshold" alert. The proxy logs:

```
http: proxy error: http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
```

When `api.segment.io` recycles an HTTP/2 connection with a graceful-shutdown GOAWAY, every in-flight POST (`/v1/t`, `/v1/p`, `/v1/i`, `/v1/g`, `/v1/m`) fails with a 502, because Go's transport cannot replay a request whose body has already been consumed unless `Request.GetBody` is set. The errors arrive in same-second bursts (~109 per 24h, roughly 0.06% of traffic).

## The fix

`bufferRequestBody` reads the incoming body into memory and sets `Request.GetBody`, so the transport can transparently replay the request on a fresh connection after a GOAWAY. It runs as the first line of the reverse proxy's `director`, and is a no-op for bodyless requests or when `GetBody` is already populated.

**Buffering is capped at 1 MiB.** Bodies past the cap stream through untouched and keep the old GOAWAY behavior, because a body too large to hold cannot be replayed anyway. Without a cap this change would trade intermittent 502s for a memory-exhaustion risk: a single 64 MiB upload took peak heap from 0.4 MiB (streaming) to 183.7 MiB (buffered). Cloud Run bounds an HTTP/1 request body at 32 MiB but allows 80 concurrent requests per instance by default, and this server sets no read timeouts, so the platform cap alone does not protect a 512 MiB instance. With the cap, that same 64 MiB upload peaks at 2.9 MiB and still arrives intact. The 1 MiB ceiling sits well above Segment's largest documented payload, a 500 KB batch.

**Whenever the body cannot be buffered, the transport gets the original byte stream.** Both the oversize path and the read-error path hand back the bytes already consumed followed by the rest of the body, so the request behaves exactly as it would have without buffering. This matters on the error path in particular: dropping the consumed prefix would leave a body short of its declared `ContentLength`, and while `net/http`'s transfer writer does reject that mismatch, relying on a downstream check rather than on this code is the kind of thing that quietly breaks later.

**The buffer is sized from the declared `ContentLength` when it fits under the cap.** For a realistic 4 KB tracking payload this drops allocation from 17592 B/op across 13 allocations to 4256 B/op across 6, and cuts latency from 3699 ns/op to about 1050 ns/op, because `ioutil.ReadAll` otherwise grows by repeated reallocation. It also lowers the adversarial ceiling from roughly 2.9x the cap per concurrent request to 1x. The declared length is trusted only to size a buffer that is already clamped to the cap, so a client that lies about its length cannot allocate more than 1 MiB.

Nothing is logged when a body exceeds the cap. Logging it would hand an attacker a log-flood amplifier against the same ERROR-severity alert this change exists to quiet; a counter exported to Cloud Monitoring is the right tool if that visibility is ever wanted.

`ioutil` is used rather than `io.ReadAll` because `go.mod` declares `go 1.13` and the Dockerfile builds with `golang:1.14.4-alpine3.11`. Pre-existing formatting quirks in `main.go` are left untouched to keep the diff minimal.

## Why retrying is safe

Go's transport only replays requests the server never processed. On the toolchain that ships this binary, `go1.14.4`, `canRetryError` admits exactly three cases: an unusable connection, a GOAWAY (retrying only streams above the frame's last-stream-id, which the upstream is guaranteed not to have handled), and `REFUSED_STREAM`. All three mean the request never reached application code. Segment additionally dedupes on `messageId`, so even a retry that did arrive cannot produce duplicate events.

Worth knowing for whoever bumps the base image: Go 1.18 and later also retry a peer `PROTOCOL_ERROR` (golang/go#47635), which carries no such guarantee. The doc comment on `bufferRequestBody` points at `canRetryError` so the constraint travels with the code. Setting `GetBody` also enables HTTP/1.1 retries of POSTs on `nothingWrittenError` for reused keep-alive connections, which is safe by definition and may quietly fix a second class of 502s.

## Tests

- `TestBufferRequestBody` asserts `GetBody` is set, `ContentLength` matches the payload, and both `req.Body` and `req.GetBody()` yield the full payload.
- `TestDirectorBuffersRequestBody` guards the wiring. Before it existed, deleting the `bufferRequestBody(req)` call from the director left the entire suite passing.
- `TestBufferRequestBodyCapBoundary` pins the cap edge at one byte under, exactly at, and one byte over, checking both whether the body was buffered and that it stayed intact.
- `TestBufferRequestBodyKeepsConsumedBytesOnReadError` covers a client that disconnects mid-upload, asserting the consumed prefix is handed back and the original error still reaches the transport.
- `TestBufferRequestBodySkipsRequestsItCannotHelp` covers both early returns, including that an existing `GetBody` is not clobbered.
- `TestProxyForwardsPostBody` and `TestProxyForwardsOversizedPostBody` proxy small and oversized POSTs end-to-end, asserting the tracking API is hit with the exact body, the CDN receives nothing, and the client gets a 200.
- The existing `TestSegmentReverseProxy` still passes.

Verified with `go vet -mod=vendor ./...`, `go test -mod=vendor ./...`, `go test -mod=vendor -race ./...`, and `go build -mod=vendor .`. Each of these mutations was checked to fail the suite: deleting the call from the director, flipping the boundary comparison to `>=`, and dropping the consumed bytes on the error path.

The failure mode was also reproduced directly against a real HTTP/2 upstream that answers the first connection with a graceful-shutdown GOAWAY (`LastStreamID=0`) after the body is written. Without the fix the proxy logs the exact prod error and returns 502 after one upstream connection; with the fix the request is replayed on a second connection, the upstream receives the intact body, and the client gets a 200. That harness needed `golang.org/x/net/http2` to craft raw frames, so it is not committed; the committed tests cover the `GetBody` contract the transport relies on.

## Deployment

The image is built and deployed by an infra GitHub Actions pipeline. After merge, verify the deploy completes and smoke-test the new revision before it takes full traffic — in particular the bot-filtering path and CDN routing for `/v1/projects` and `/analytics-next/bundles`, alongside a POST to `/v1/t`. Because the 502s are intermittent and bursty, the signal to watch is the absence of the `cannot retry err ... after Request.Body was written` line over a full day rather than an immediate change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da612714-027e-4e05-bf70-86189df8f6d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da612714-027e-4e05-bf70-86189df8f6d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

